### PR TITLE
Replace deprecated `dbglog()` function use with dokuwiki\Logger

### DIFF
--- a/StaticMap.php
+++ b/StaticMap.php
@@ -27,6 +27,7 @@ use geoPHP\Geometry\LineString;
 use geoPHP\Geometry\Point;
 use geoPHP\Geometry\Polygon;
 use geoPHP\geoPHP;
+use dokuwiki\Logger;
 
 /**
  *

--- a/StaticMap.php
+++ b/StaticMap.php
@@ -170,7 +170,7 @@ class StaticMap
                 $this->autoZoom();
             }
         } catch (Exception $e) {
-            dbglog($e);
+            Logger::debug($e);
         }
 
         // use map cache, so check cache for map
@@ -221,7 +221,7 @@ class StaticMap
         }
 
         if (count($geoms) <= 1) {
-            dbglog($geoms, "StaticMap::autoZoom: Skip setting autozoom options");
+            Logger::debug("StaticMap::autoZoom: Skip setting autozoom options", $geoms);
             return;
         }
 
@@ -233,17 +233,17 @@ class StaticMap
         // $vy00 = log(tan(M_PI*(0.25 + $centroid->getY()/360)));
         $vy0 = log(tan(M_PI * (0.25 + $bbox ['miny'] / 360)));
         $vy1 = log(tan(M_PI * (0.25 + $bbox ['maxy'] / 360)));
-        dbglog("StaticMap::autoZoom: vertical resolution: $vy0, $vy1");
+        Logger::debug("StaticMap::autoZoom: vertical resolution: $vy0, $vy1");
         if ($vy1 - $vy0 === 0.0) {
             $resolutionVertical = 0;
-            dbglog("StaticMap::autoZoom: using $resolutionVertical");
+            Logger::debug("StaticMap::autoZoom: using $resolutionVertical");
         } else {
             $zoomFactorPowered  = ($this->height / 2) / (40.7436654315252 * ($vy1 - $vy0));
             $resolutionVertical = 360 / ($zoomFactorPowered * $this->tileSize);
         }
         // determine horizontal resolution
         $resolutionHorizontal = ($bbox ['maxx'] - $bbox ['minx']) / $this->width;
-        dbglog("StaticMap::autoZoom: using $resolutionHorizontal");
+        Logger::debug("StaticMap::autoZoom: using $resolutionHorizontal");
         $resolution           = max($resolutionHorizontal, $resolutionVertical) * $paddingFactor;
         $zoom                 = $this->zoom;
         if ($resolution > 0) {
@@ -255,7 +255,7 @@ class StaticMap
         }
         $this->lon = $centroid->getX();
         $this->lat = $centroid->getY();
-        dbglog("StaticMap::autoZoom: Set autozoom options to: z: $this->zoom, lon: $this->lon, lat: $this->lat");
+        Logger::debug("StaticMap::autoZoom: Set autozoom options to: z: $this->zoom, lon: $this->lon, lat: $this->lat");
     }
 
     public function checkMapCache(): bool
@@ -298,21 +298,21 @@ class StaticMap
             try {
                 $this->drawKML();
             } catch (exception $e) {
-                dbglog('failed to load KML file', $e);
+                Logger::error('failed to load KML file', $e);
             }
         }
         if (file_exists($this->gpxFileName)) {
             try {
                 $this->drawGPX();
             } catch (exception $e) {
-                dbglog('failed to load GPX file', $e);
+                Logger::error('failed to load GPX file', $e);
             }
         }
         if (file_exists($this->geojsonFileName)) {
             try {
                 $this->drawGeojson();
             } catch (exception $e) {
-                dbglog('failed to load GeoJSON file', $e);
+                Logger::error('failed to load GeoJSON file', $e);
             }
         }
 
@@ -386,7 +386,7 @@ class StaticMap
                 }
                 $destX = ($x - $startX) * $this->tileSize + $this->offsetX;
                 $destY = ($y - $startY) * $this->tileSize + $this->offsetY;
-                dbglog($this->tileSize, "imagecopy tile into image: $destX, $destY");
+                Logger::debug("imagecopy tile into image: $destX, $destY", $this->tileSize);
                 imagecopy(
                     $this->image,
                     $tileImage,
@@ -421,7 +421,7 @@ class StaticMap
             curl_setopt($ch, CURLOPT_USERAGENT, $_UA);
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
             curl_setopt($ch, CURLOPT_URL, $url . $this->apikey);
-            dbglog("StaticMap::fetchTile: getting: $url using curl_exec");
+            Logger::debug("StaticMap::fetchTile: getting: $url using curl_exec");
             $tile = curl_exec($ch);
             curl_close($ch);
         } else {
@@ -437,7 +437,9 @@ class StaticMap
             }
 
             $context = stream_context_create($opts);
-            // dbglog("StaticMap::fetchTile: getting: $url . $this->apikey using file_get_contents and options $opts");
+            Logger::debug(
+                "StaticMap::fetchTile: getting: $url . $this->apikey using file_get_contents and options $opts"
+            );
             $tile = file_get_contents($url . $this->apikey, false, $context);
         }
         if ($tile && $this->useTileCache) {

--- a/admin/purge.php
+++ b/admin/purge.php
@@ -74,7 +74,7 @@ class admin_plugin_openlayersmap_purge extends AdminPlugin
     private function rrmdir(string $sDir): bool
     {
         if (is_dir($sDir)) {
-            dbglog($sDir, 'admin_plugin_openlayersmap_purge::rrmdir: recursively removing path: ');
+            Logger::debug('admin_plugin_openlayersmap_purge::rrmdir: recursively removing path: ', $sDir);
             $sDir = rtrim($sDir, '/');
             $oDir = dir($sDir);
             while (($sFile = $oDir->read()) !== false) {

--- a/admin/purge.php
+++ b/admin/purge.php
@@ -1,9 +1,7 @@
 <?php
 
-use dokuwiki\Extension\AdminPlugin;
-
 /*
- * Copyright (c) 2008-2015 Mark C. Prins <mprins@users.sf.net>
+ * Copyright (c) 2008-2023 Mark C. Prins <mprins@users.sf.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -19,6 +17,9 @@ use dokuwiki\Extension\AdminPlugin;
  *
  * @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
  */
+use dokuwiki\Extension\AdminPlugin;
+use dokuwiki\Logger;
+
 /**
  * DokuWiki Plugin openlayersmap (Admin Component).
  * This component purges the cached tiles and maps.

--- a/helper/staticmap.php
+++ b/helper/staticmap.php
@@ -71,7 +71,7 @@ class helper_plugin_openlayersmap_staticmap extends Plugin
         string $apikey = ''
     ): string {
         global $conf;
-        // dbglog($markers,'helper_plugin_openlayersmap_staticmap::getMap: markers :');
+        // Logger::debug('helper_plugin_openlayersmap_staticmap::getMap: markers :',$markers);
 
         // normalize zoom
         $zoom = $zoom ?: 0;
@@ -91,9 +91,9 @@ class helper_plugin_openlayersmap_staticmap extends Plugin
 
         // cleanup/validate gpx/kml
         $kml = $this->mediaIdToPath($kml);
-        // dbglog($kml,'helper_plugin_openlayersmap_staticmap::getMap: kml file:');
+        // Logger::debug('helper_plugin_openlayersmap_staticmap::getMap: kml file:',$kml);
         $gpx = $this->mediaIdToPath($gpx);
-        // dbglog($gpx,'helper_plugin_openlayersmap_staticmap::getMap: gpx file:');
+        // Logger::debug('helper_plugin_openlayersmap_staticmap::getMap: gpx file:',$gpx);
         $geojson = $this->mediaIdToPath($geojson);
 
         // create map

--- a/helper/staticmap.php
+++ b/helper/staticmap.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2008-2022 Mark C. Prins <mprins@users.sf.net>
+ * Copyright (c) 2008-2023 Mark C. Prins <mprins@users.sf.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -17,6 +17,7 @@
  *
  * @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
  */
+use dokuwiki\Logger;
 use dokuwiki\Extension\Plugin;
 use dokuwiki\plugin\openlayersmap\StaticMap;
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   openlayersmap
 author Mark C. Prins
 email  mprins@users.sf.net
-date   2023-11-15
+date   2023-11-26
 name   OpenLayers map plugin for DokuWiki
 desc   Provides a syntax for rendering an OpenLayers based map in a wiki page. Uses OpenLayers 8.1.0
 url    https://www.dokuwiki.org/plugin:openlayersmap

--- a/syntax/olmap.php
+++ b/syntax/olmap.php
@@ -124,7 +124,7 @@ class syntax_plugin_openlayersmap_olmap extends SyntaxPlugin
                 $_nocache = true;
                 $imgUrl   .= $this->getBing($gmap, $overlay) . "&.png";
             }
-        } /* elseif (stripos ( $gmap ['baselyr'], 'mapquest' ) !== false) {
+         /* elseif (stripos ( $gmap ['baselyr'], 'mapquest' ) !== false) {
             // MapQuest
             if (! $this->getConf ( 'mapquestAPIKey' )) {
                 // no API key for MapQuest, use OSM
@@ -137,14 +137,15 @@ class syntax_plugin_openlayersmap_olmap extends SyntaxPlugin
                 $imgUrl .= $this->_getMapQuest ( $gmap, $overlay );
                 $imgUrl .= "&.png";
             }
-        } */ else {
+        } */
+        } else {
             // default OSM
             $_firstimageID = $this->getStaticOSM($gmap, $overlay);
             $imgUrl        .= $_firstimageID;
             if ($this->getConf('optionStaticMapGenerator') == 'remote') {
                 $imgUrl .= "&.png";
             }
-}
+        }
 
         // append dw p_render specific params and render
         $imgUrl .= "?" . str_replace("px", "", $gmap ['width']) . "x"
@@ -152,85 +153,85 @@ class syntax_plugin_openlayersmap_olmap extends SyntaxPlugin
         $imgUrl .= "&nolink";
 
         // add nocache option for selected services
-if ($_nocache) {
-    $imgUrl .= "&nocache";
-}
+        if ($_nocache) {
+            $imgUrl .= "&nocache";
+        }
 
         $imgUrl .= " |" . $gmap ['summary'] . " }}";
 
         $mapid = $gmap ['id'];
         // create a javascript parameter string for the map
         $param = '';
-foreach ($gmap as $key => $val) {
-    $param .= is_numeric($val) ? "$key: $val, " : "$key: '" . hsc($val) . "', ";
-}
-if (!empty($param)) {
-    $param = substr($param, 0, -2);
-}
+        foreach ($gmap as $key => $val) {
+            $param .= is_numeric($val) ? "$key: $val, " : "$key: '" . hsc($val) . "', ";
+        }
+        if (!empty($param)) {
+            $param = substr($param, 0, -2);
+        }
         unset($gmap ['id']);
 
         // create a javascript serialisation of the point data
         $poi      = '';
         $poitable = '';
         $rowId    = 0;
-if ($overlay !== []) {
-    foreach ($overlay as $data) {
-        [$lat, $lon, $text, $angle, $opacity, $img] = $data;
-        $rowId++;
-        $poi .= ", {lat:$lat,lon:$lon,txt:'$text',angle:$angle,opacity:$opacity,img:'$img',rowId: $rowId}";
+        if ($overlay !== []) {
+            foreach ($overlay as $data) {
+                [$lat, $lon, $text, $angle, $opacity, $img] = $data;
+                $rowId++;
+                $poi .= ", {lat:$lat,lon:$lon,txt:'$text',angle:$angle,opacity:$opacity,img:'$img',rowId: $rowId}";
 
-        if ($this->getConf('displayformat') === 'DMS') {
-            $lat = $this->convertLat($lat);
-            $lon = $this->convertLon($lon);
-        } else {
-            $lat .= 'º';
-            $lon .= 'º';
-        }
+                if ($this->getConf('displayformat') === 'DMS') {
+                    $lat = $this->convertLat($lat);
+                    $lon = $this->convertLon($lon);
+                } else {
+                    $lat .= 'º';
+                    $lon .= 'º';
+                }
 
-        $poitable .= '
+                $poitable .= '
                     <tr>
                     <td class="rowId">' . $rowId . '</td>
                     <td class="icon"><img src="' . DOKU_BASE . 'lib/plugins/openlayersmap/icons/' . $img . '" alt="'
-            . substr($img, 0, -4) . $this->getlang('alt_legend_poi') . '" /></td>
+                    . substr($img, 0, -4) . $this->getlang('alt_legend_poi') . '" /></td>
                     <td class="lat" title="' . $this->getLang('olmapPOIlatTitle') . '">' . $lat . '</td>
                     <td class="lon" title="' . $this->getLang('olmapPOIlonTitle') . '">' . $lon . '</td>
                     <td class="txt">' . $text . '</td>
                     </tr>';
-    }
-    $poi = substr($poi, 2);
-}
-if (!empty($gmap ['kmlfile'])) {
-    $poitable .= '
+            }
+            $poi = substr($poi, 2);
+        }
+        if (!empty($gmap ['kmlfile'])) {
+            $poitable .= '
                     <tr>
                     <td class="rowId"><img src="' . DOKU_BASE
-        . 'lib/plugins/openlayersmap/toolbar/kml_file.png" alt="KML file" /></td>
+                . 'lib/plugins/openlayersmap/toolbar/kml_file.png" alt="KML file" /></td>
                     <td class="icon"><img src="' . DOKU_BASE . 'lib/plugins/openlayersmap/toolbar/kml_line.png" alt="'
-        . $this->getlang('alt_legend_kml') . '" /></td>
+                . $this->getlang('alt_legend_kml') . '" /></td>
                     <td class="txt" colspan="3">KML track: ' . $this->getFileName($gmap ['kmlfile']) . '</td>
                     </tr>';
-}
-if (!empty($gmap ['gpxfile'])) {
-    $poitable .= '
+        }
+        if (!empty($gmap ['gpxfile'])) {
+            $poitable .= '
                     <tr>
                     <td class="rowId"><img src="' . DOKU_BASE
-        . 'lib/plugins/openlayersmap/toolbar/gpx_file.png" alt="GPX file" /></td>
+                . 'lib/plugins/openlayersmap/toolbar/gpx_file.png" alt="GPX file" /></td>
                     <td class="icon"><img src="' . DOKU_BASE
-        . 'lib/plugins/openlayersmap/toolbar/gpx_line.png" alt="'
-        . $this->getlang('alt_legend_gpx') . '" /></td>
+                . 'lib/plugins/openlayersmap/toolbar/gpx_line.png" alt="'
+                . $this->getlang('alt_legend_gpx') . '" /></td>
                     <td class="txt" colspan="3">GPX track: ' . $this->getFileName($gmap ['gpxfile']) . '</td>
                     </tr>';
-}
-if (!empty($gmap ['geojsonfile'])) {
-    $poitable .= '
+        }
+        if (!empty($gmap ['geojsonfile'])) {
+            $poitable .= '
                     <tr>
                     <td class="rowId"><img src="' . DOKU_BASE
-        . 'lib/plugins/openlayersmap/toolbar/geojson_file.png" alt="GeoJSON file" /></td>
+                . 'lib/plugins/openlayersmap/toolbar/geojson_file.png" alt="GeoJSON file" /></td>
                     <td class="icon"><img src="' . DOKU_BASE
-        . 'lib/plugins/openlayersmap/toolbar/geojson_line.png" alt="'
-        . $this->getlang('alt_legend_geojson') . '" /></td>
+                . 'lib/plugins/openlayersmap/toolbar/geojson_line.png" alt="'
+                . $this->getlang('alt_legend_geojson') . '" /></td>
                     <td class="txt" colspan="3">GeoJSON track: ' . $this->getFileName($gmap ['geojsonfile']) . '</td>
                     </tr>';
-}
+        }
 
         $autozoom = empty($gmap ['autozoom']) ? $this->getConf('autoZoomMap') : $gmap ['autozoom'];
         $js       = "{mapOpts: {" . $param . ", displayformat: '" . $this->getConf('displayformat')
@@ -812,7 +813,7 @@ if (!empty($gmap ['geojsonfile'])) {
                 $renderer->meta ['geo'] ['lon'] = $mainLon;
                 if (($geophp = plugin_load('helper', 'geophp')) !== null) {
                     // if we have the geoPHP helper, add the geohash
-                    try{
+                    try {
                         $renderer->meta['geo']['geohash'] = (new Point($mainLon, $mainLat))->out('geohash');
                     } catch (Exception $e) {
                         Logger::error("Failed to create geohash for: $mainLat, $mainLon");
@@ -830,7 +831,7 @@ if (!empty($gmap ['geojsonfile'])) {
                     //Logger::debug(
                     // 'olmap::render#rendering image relation metadata for _firstimage as $img was empty or same.',
                     // $_firstimage);
-                    
+
                     // This seems to never work; the firstimage entry in the .meta file is empty
                     // $renderer->meta['relation']['firstimage'] = $_firstimage;
                     // ... and neither does this; the firstimage entry in the .meta file is empty

--- a/syntax/olmap.php
+++ b/syntax/olmap.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright (c) 2008-2021 Mark C. Prins <mprins@users.sf.net>
+ * Copyright (c) 2008-2023 Mark C. Prins <mprins@users.sf.net>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -157,8 +157,6 @@ if ($_nocache) {
 }
 
         $imgUrl .= " |" . $gmap ['summary'] . " }}";
-
-        // dbglog($imgUrl,"complete image tags is:");
 
         $mapid = $gmap ['id'];
         // create a javascript parameter string for the map
@@ -383,7 +381,6 @@ if (!empty($gmap ['geojsonfile'])) {
         if ($this->getConf('googleAPIkey')) {
             $imgUrl .= "&key=" . $this->getConf('googleAPIkey');
         }
-        // dbglog($imgUrl,'syntax_plugin_openlayersmap_olmap::getGoogle: Google image url is:');
         return $imgUrl;
     }
 
@@ -446,7 +443,6 @@ if (!empty($gmap ['geojsonfile'])) {
        }
        $imgUrl .= "&imageType=png&type=" . $maptype;
        $imgUrl .= "&key=".$this->getConf ( 'mapquestAPIKey' );
-       // dbglog($imgUrl,'syntax_plugin_openlayersmap_olmap::_getMapQuest: MapQuest image url is:');
        return $imgUrl;
    }
    */
@@ -468,13 +464,13 @@ if (!empty($gmap ['geojsonfile'])) {
         if ($this->getConf('optionStaticMapGenerator') === 'local') {
             // using local basemap composer
             if (($myMap = plugin_load('helper', 'openlayersmap_staticmap')) === null) {
-                dbglog(
-                    $myMap,
-                    'openlayersmap_staticmap plugin is not available for use.'
+                Logger::error(
+                    'openlayersmap_staticmap plugin is not available for use.',
+                    $myMap
                 );
             }
             if (($geophp = plugin_load('helper', 'geophp')) === null) {
-                dbglog($geophp, 'geophp plugin is not available for use.');
+                Logger::debug('geophp plugin is not available for use.', $geophp);
             }
             $size = str_replace("px", "", $gmap ['width']) . "x"
                 . str_replace("px", "", $gmap ['height']);
@@ -816,11 +812,11 @@ if (!empty($gmap ['geojsonfile'])) {
                 $renderer->meta ['geo'] ['lon'] = $mainLon;
                 if (($geophp = plugin_load('helper', 'geophp')) !== null) {
                     // if we have the geoPHP helper, add the geohash
-
-                    // fails with older php versions..
-                    // $renderer->meta['geo']['geohash'] = (new Point($mainLon,$mainLat))->out('geohash');
-                    $p                                  = new Point($mainLon, $mainLat);
-                    $renderer->meta ['geo'] ['geohash'] = $p->out('geohash');
+                    try{
+                        $renderer->meta['geo']['geohash'] = (new Point($mainLon, $mainLat))->out('geohash');
+                    } catch (Exception $e) {
+                        Logger::error("Failed to create geohash for: $mainLat, $mainLon");
+                    }
                 }
             }
 
@@ -831,15 +827,15 @@ if (!empty($gmap ['geojsonfile'])) {
                 $rel = p_get_metadata($ID, 'relation', METADATA_RENDER_USING_CACHE);
                 // $img = $rel ['firstimage'];
                 if (empty($rel ['firstimage']) /* || $img == $_firstimage*/) {
-                    //dbglog ( $_firstimage,
-                    // 'olmap::render#rendering image relation metadata for _firstimage as $img was empty or same.' );
+                    //Logger::debug(
+                    // 'olmap::render#rendering image relation metadata for _firstimage as $img was empty or same.',
+                    // $_firstimage);
+                    
                     // This seems to never work; the firstimage entry in the .meta file is empty
                     // $renderer->meta['relation']['firstimage'] = $_firstimage;
-
                     // ... and neither does this; the firstimage entry in the .meta file is empty
                     // $relation = array('relation'=>array('firstimage'=>$_firstimage));
                     // p_set_metadata($ID, $relation, false, false);
-
                     // ... this works
                     $renderer->internalmedia($_firstimage, $poitabledesc);
                 }

--- a/syntax/olmap.php
+++ b/syntax/olmap.php
@@ -19,6 +19,7 @@
  */
 use dokuwiki\Extension\SyntaxPlugin;
 use geoPHP\Geometry\Point;
+use dokuwiki\Logger;
 
 /**
  * DokuWiki Plugin openlayersmap (Syntax Component).

--- a/syntax/osmlayer.php
+++ b/syntax/osmlayer.php
@@ -92,7 +92,6 @@ class syntax_plugin_openlayersmap_osmlayer extends SyntaxPlugin
                 $data [$key] = $val;
             }
         }
-        // dbglog($data,'syntax_plugin_overlayer::handle: parsed data is:');
         return $data;
     }
 

--- a/syntax/wmslayer.php
+++ b/syntax/wmslayer.php
@@ -92,7 +92,6 @@ class syntax_plugin_openlayersmap_wmslayer extends SyntaxPlugin
                 $data [$key] = $val;
             }
         }
-        // dbglog($data,'syntax_plugin_overlayer::handle: parsed data is:');
         return $data;
     }
 


### PR DESCRIPTION
both the `old-stable` as well as the `stable` branch have deprecated this function