### PR TITLE
Update the OSM url to the preferred url

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   openlayersmap
 author Mark C. Prins
 email  mprins@users.sf.net
-date   2022-08-20
+date   2022-08-31
 name   OpenLayers map plugin for DokuWiki
-desc   Provides a syntax for rendering an OpenLayers based map in a wiki page. Uses OpenLayers 6.14.1
+desc   Provides a syntax for rendering an OpenLayers based map in a wiki page. Uses OpenLayers 6.15.1
 url    https://www.dokuwiki.org/plugin:openlayersmap

--- a/script.js
+++ b/script.js
@@ -116,7 +116,10 @@ function createMap(mapOpts, poi) {
                 visible: true,
                 title:   'OSM',
                 type:    'base',
-                source:  new ol.source.OSM()
+                source:  new ol.source.OSM({
+                    // can be removed after upgrade to OL 7.1, see https://github.com/openlayers/openlayers/pull/14062
+                    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
+                })
             }));
 
         baseLyrGroup.getLayers().push(


### PR DESCRIPTION
see https://github.com/openlayers/openlayers/pull/14062 and https://github.com/openstreetmap/operations/issues/737

this should/can be reverted after upgrade to OL 7.1