### PR TITLE
Add padding for the autozoom option

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   openlayersmap
 author Mark C. Prins
 email  mprins@users.sf.net
-date   2023-03-05
+date   2023-05-23
 name   OpenLayers map plugin for DokuWiki
 desc   Provides a syntax for rendering an OpenLayers based map in a wiki page. Uses OpenLayers 7.3.0
 url    https://www.dokuwiki.org/plugin:openlayersmap

--- a/script.js
+++ b/script.js
@@ -71,6 +71,7 @@ function createMap(mapOpts, poi) {
 
     // const mapOpts = olMapData[0].mapOpts;
     // const poi = olMapData[0].poi;
+    const autoZoom_options =  {padding: [16, 16, 16, 16]};
 
     if (!olEnable) {
         return null;
@@ -298,7 +299,7 @@ function createMap(mapOpts, poi) {
     overlayGroup.getLayers().push(vectorLayer);
     if (mapOpts.autozoom) {
         extent = ol.extent.extend(extent, vectorSource.getExtent());
-        map.getView().fit(extent);
+        map.getView().fit(extent, autoZoom_options);
     }
 
     if (mapOpts.controls === 1) {
@@ -334,7 +335,7 @@ function createMap(mapOpts, poi) {
             if (mapOpts.autozoom) {
                 kmlSource.once('change', function () {
                     extent = ol.extent.extend(extent, kmlSource.getExtent());
-                    map.getView().fit(extent);
+                    map.getView().fit(extent, autoZoom_options);
                 });
             }
         } catch (e) {
@@ -403,7 +404,7 @@ function createMap(mapOpts, poi) {
             if (mapOpts.autozoom) {
                 geoJsonSource.once('change', function () {
                     extent = ol.extent.extend(extent, geoJsonSource.getExtent());
-                    map.getView().fit(extent);
+                    map.getView().fit(extent, autoZoom_options);
                 });
             }
         } catch (e) {
@@ -454,7 +455,7 @@ function createMap(mapOpts, poi) {
             if (mapOpts.autozoom) {
                 gpxSource.once('change', function () {
                     extent = ol.extent.extend(extent, gpxSource.getExtent());
-                    map.getView().fit(extent);
+                    map.getView().fit(extent, autoZoom_options);
                 });
             }
         } catch (e) {


### PR DESCRIPTION
this will ensure that icons fall inside the map instead of on the border