### PR TITLE
prevent a console error when olEnable is not defined

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   openlayersmap
 author Mark C. Prins
 email  mprins@users.sf.net
-date   2023-05-23
+date   2023-05-27
 name   OpenLayers map plugin for DokuWiki
 desc   Provides a syntax for rendering an OpenLayers based map in a wiki page. Uses OpenLayers 7.3.0
 url    https://www.dokuwiki.org/plugin:openlayersmap

--- a/script.js
+++ b/script.js
@@ -695,7 +695,7 @@ function olovAddToMap() {
 
 /** init. */
 function olInit() {
-    if (olEnable) {
+    if (typeof olEnable !== 'undefined' && olEnable) {
         // add info window to DOM
         const frag = document.createDocumentFragment(),
             temp = document.createElement('div');


### PR DESCRIPTION
Prevent `Uncaught ReferenceError: olEnable is not defined` when there is no map on a page