### PR TITLE
Add icon name as name parameter in `geo:` link

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   openlayersmap
 author Mark C. Prins
 email  mprins@users.sf.net
-date   2023-06-02
+date   2023-06-05
 name   OpenLayers map plugin for DokuWiki
 desc   Provides a syntax for rendering an OpenLayers based map in a wiki page. Uses OpenLayers 7.4.0
 url    https://www.dokuwiki.org/plugin:openlayersmap

--- a/script.js
+++ b/script.js
@@ -523,12 +523,22 @@ function createMap(mapOpts, poi) {
             }
             if (selFeature.get('img') !== undefined) {
                 const _alt = selFeature.get('alt');
+                // Android Maps intent: https://developer.android.com/guide/components/intents-common#Maps
+                // geo uri scheme: https://en.wikipedia.org/wiki/Geo_URI_scheme
+                // geo uri reference: https://tools.ietf.org/html/rfc5870
+                // OSM wiki: https://wiki.openstreetmap.org/wiki/Geo_URI_scheme
                 pContent += '<div class="coord" title="lat;lon">' +
                     '<img alt="' + _alt + '" src="' + DOKU_BASE + 'lib/plugins/openlayersmap/icons/' + selFeature.get('img') +
                     '" width="16" height="16" ' + 'style="transform:rotate(' + selFeature.get('angle') + 'deg)" />&nbsp;' +
-                    '<a href="geo:' + selFeature.get('lat') + ',' + selFeature.get('lon') + '?q=' + selFeature.get('lat') +
-                    ',' + selFeature.get('lon') + '(' + selFeature.get('alt') + ')" title="Open in navigation app">' +
-                    ol.coordinate.format([selFeature.get('lon'), selFeature.get('lat')], '{x}º; {y}º', 4) + '</a></div>';
+                    '<a href="geo:' + selFeature.get('lat') + ','
+                                    + selFeature.get('lon') +
+                           '?q='    + selFeature.get('lat') + ',' +
+                                      selFeature.get('lon') +
+                           '&name=' + selFeature.get('alt') +
+                           ';z=16" title="Open in navigation app">' +
+                    ol.coordinate.format([selFeature.get('lon'), selFeature.get('lat')], '{x}º; {y}º', 4)
+                    + '</a>' +
+                    '</div>';
             }
             content.innerHTML = pContent;
         } else {


### PR DESCRIPTION
instead of just appending some parentheses and the icon name which confuses google maps (on desktop)

test with:
- [x] desktop gmaps
- [x] android gmaps
- [x] android navfree
- [x] android organicmaps

close #55