### PR TITLE
Do not enable Stamen (now Stadia Maps) tiles by default

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -23,7 +23,7 @@
 $conf['bingAPIKey']               = '';
 $conf['tfApiKey']                 = '';
 $conf['iconUrlOverload']          = '';
-$conf['enableStamen']             = 1;
+$conf['enableStamen']             = 0;
 $conf['enableGoogle']             = 0;
 $conf['googleAPIkey']             = '';
 $conf['enableOSM']                = 1;


### PR DESCRIPTION
Stamen tiles are no longer a free service and require an API key or domain registration. Admins will have to setup domain authentication, see https://docs.stadiamaps.com/guides/migrating-from-stamen-map-tiles/ and https://github.com/openlayers/openlayers/pull/14989