### PR TITLE
Implement OSM referrer policy in static map and fix whole world views for static maps

### DIFF
--- a/StaticMap.php
+++ b/StaticMap.php
@@ -21,6 +21,7 @@
  */
 namespace dokuwiki\plugin\openlayersmap;
 
+use Exception;
 use geoPHP\Geometry\Geometry;
 use geoPHP\Geometry\GeometryCollection;
 use geoPHP\Geometry\LineString;
@@ -38,58 +39,60 @@ use dokuwiki\Logger;
 class StaticMap
 {
     // the final output
-    private $tileSize = 256;
-    private $tileInfo = [
+    private int $tileSize = 256;
+    private array $tileInfo = [
         // OSM sources
-        'openstreetmap' => ['txt'  => '(c) OpenStreetMap data/ODbl', 'logo' => 'osm_logo.png', 'url'  => 'https://tile.openstreetmap.org/{Z}/{X}/{Y}.png'],
+        'openstreetmap' => ['txt' => '(c) OpenStreetMap data/ODbL', 'logo' => 'osm_logo.png', 'url' => 'https://tile.openstreetmap.org/{Z}/{X}/{Y}.png'],
         // OpenTopoMap sources
-        'opentopomap' => ['txt'  => '(c) OpenStreetMap data/ODbl, SRTM | style: (c) OpenTopoMap', 'logo' => 'osm_logo.png', 'url'  => 'https:/tile.opentopomap.org/{Z}/{X}/{Y}.png'],
+        'opentopomap' => ['txt' => '(c) OpenStreetMap data/ODbL, SRTM | style: (c) OpenTopoMap', 'logo' => 'osm_logo.png', 'url' => 'https://tile.opentopomap.org/{Z}/{X}/{Y}.png'],
         // OCM sources
-        'cycle'         => ['txt'  => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url'  => 'https://tile.thunderforest.com/cycle/{Z}/{X}/{Y}.png'],
-        'transport'     => ['txt'  => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url'  => 'https://tile.thunderforest.com/transport/{Z}/{X}/{Y}.png'],
-        'landscape'     => ['txt'  => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url'  => 'https://tile.thunderforest.com/landscape/{Z}/{X}/{Y}.png'],
-        'outdoors'      => ['txt'  => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url'  => 'https://tile.thunderforest.com/outdoors/{Z}/{X}/{Y}.png'],
-        'toner'    => ['txt'  => '(c) Stadia Maps;Stamen Design;OpenStreetMap contributors', 'logo' => 'stamen.png', 'url'  => 'https://tiles-eu.stadiamaps.com/tiles/stamen_toner/{Z}/{X}/{Y}.png'],
-        'terrain'       => ['txt'  => '(c) Stadia Maps;Stamen Design;OpenStreetMap contributors', 'logo' => 'stamen.png', 'url'  => 'https://tiles-eu.stadiamaps.com/tiles/stamen_terrain/{Z}/{X}/{Y}.png'],
+        'cycle' => ['txt' => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url' => 'https://tile.thunderforest.com/cycle/{Z}/{X}/{Y}.png'],
+        'transport' => ['txt' => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url' => 'https://tile.thunderforest.com/transport/{Z}/{X}/{Y}.png'],
+        'landscape' => ['txt' => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url' => 'https://tile.thunderforest.com/landscape/{Z}/{X}/{Y}.png'],
+        'outdoors' => ['txt' => '(c) Thunderforest maps', 'logo' => 'tf_logo.png', 'url' => 'https://tile.thunderforest.com/outdoors/{Z}/{X}/{Y}.png'],
+        'toner' => ['txt' => '(c) Stadia Maps;Stamen Design;OpenStreetMap contributors', 'logo' => 'stamen.png', 'url' => 'https://tiles-eu.stadiamaps.com/tiles/stamen_toner/{Z}/{X}/{Y}.png'],
+        'terrain' => ['txt' => '(c) Stadia Maps;Stamen Design;OpenStreetMap contributors', 'logo' => 'stamen.png', 'url' => 'https://tiles-eu.stadiamaps.com/tiles/stamen_terrain/{Z}/{X}/{Y}.png'],
     ];
-    private $tileDefaultSrc = 'openstreetmap';
+    private string $tileDefaultSrc = 'openstreetmap';
 
     // set up markers
-    private $markerPrototypes = [
+    private array $markerPrototypes = [
         // found at http://www.mapito.net/map-marker-icons.html
         // these are 17x19 px with a pointer at the bottom left
-        'lightblue' => ['regex'        => '/^lightblue(\d+)$/', 'extension'    => '.png', 'shadow'       => false, 'offsetImage'  => '0,-19', 'offsetShadow' => false],
+        'lightblue' => ['regex' => '/^lightblue(\d+)$/', 'extension' => '.png', 'shadow' => false, 'offsetImage' => '0,-19', 'offsetShadow' => false],
         // openlayers std markers are 21x25px with shadow
-        'ol-marker' => ['regex'        => '/^marker(|-blue|-gold|-green|-red)+$/', 'extension'    => '.png', 'shadow'       => 'marker_shadow.png', 'offsetImage'  => '-10,-25', 'offsetShadow' => '-1,-13'],
+        'ol-marker' => ['regex' => '/^marker(|-blue|-gold|-green|-red)+$/', 'extension' => '.png', 'shadow' => 'marker_shadow.png', 'offsetImage' => '-10,-25', 'offsetShadow' => '-1,-13'],
         // these are 16x16 px
-        'ww_icon'   => ['regex'        => '/ww_\S+$/', 'extension'    => '.png', 'shadow'       => false, 'offsetImage'  => '-8,-8', 'offsetShadow' => false],
+        'ww_icon' => ['regex' => '/ww_\S+$/', 'extension' => '.png', 'shadow' => false, 'offsetImage' => '-8,-8', 'offsetShadow' => false],
         // assume these are 16x16 px
-        'rest'      => ['regex'        => '/^(?!lightblue(\d+)$)(?!(ww_\S+$))(?!marker(|-blue|-gold|-green|-red)+$)(.*)/', 'extension'    => '.png', 'shadow'       => 'marker_shadow.png', 'offsetImage'  => '-8,-8', 'offsetShadow' => '-1,-1'],
+        'rest' => ['regex' => '/^(?!lightblue(\d+)$)(?!(ww_\S+$))(?!marker(|-blue|-gold|-green|-red)+$)(.*)/', 'extension' => '.png', 'shadow' => 'marker_shadow.png', 'offsetImage' => '-8,-8', 'offsetShadow' => '-1,-1'],
     ];
-    private $centerX;
-    private $centerY;
-    private $offsetX;
-    private $offsetY;
+    // note event hough $centerX, $centerY, $offsetX and $offsetY are defined as float,
+    //   these are actually integer numbers, but the php floor()/ceil() functions return a float
+    private float $centerX;
+    private float $centerY;
+    private float $offsetX;
+    private float $offsetY;
     private $image;
-    private $zoom;
-    private $lat;
-    private $lon;
-    private $width;
-    private $height;
-    private $markers;
-    private $maptype;
-    private $kmlFileName;
-    private $gpxFileName;
-    private $geojsonFileName;
-    private $autoZoomExtent;
-    private $apikey;
-    private $tileCacheBaseDir;
-    private $mapCacheBaseDir;
-    private $mediaBaseDir;
-    private $useTileCache;
-    private $mapCacheID = '';
-    private $mapCacheFile = '';
-    private $mapCacheExtension = 'png';
+    private int $zoom;
+    private float $lat;
+    private float $lon;
+    private int $width;
+    private int $height;
+    private array $markers;
+    private string $maptype;
+    private string $kmlFileName;
+    private string $gpxFileName;
+    private string $geojsonFileName;
+    private bool $autoZoomExtent;
+    private string $apikey;
+    private string $tileCacheBaseDir;
+    private string $mapCacheBaseDir;
+    private string $mediaBaseDir;
+    private bool $useTileCache;
+    private string $mapCacheID = '';
+    private string $mapCacheFile = '';
+    private string $mapCacheExtension = 'png';
 
     /**
      * Constructor.
@@ -334,9 +337,9 @@ class StaticMap
      *
      * @param float $long
      * @param int   $zoom
-     * @return float|int
+     * @return float
      */
-    public function lonToTile(float $long, int $zoom)
+    public function lonToTile(float $long, int $zoom): float
     {
         return (($long + 180) / 360) * 2 ** $zoom;
     }
@@ -345,9 +348,9 @@ class StaticMap
      *
      * @param float $lat
      * @param int   $zoom
-     * @return float|int
+     * @return float
      */
-    public function latToTile(float $lat, int $zoom)
+    public function latToTile(float $lat, int $zoom): float
     {
         return (1 - log(tan($lat * M_PI / 180) + 1 / cos($lat * M_PI / 180)) / M_PI) / 2 * 2 ** $zoom;
     }
@@ -420,6 +423,7 @@ class StaticMap
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($ch, CURLOPT_USERAGENT, $_UA);
+            curl_setopt($ch, CURLOPT_REFERER, DOKU_URL);
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
             curl_setopt($ch, CURLOPT_URL, $url . $this->apikey);
             Logger::debug("StaticMap::fetchTile: getting: $url using curl_exec");
@@ -428,9 +432,12 @@ class StaticMap
         } else {
             // use file_get_contents
             global $conf;
-            $opts = ['http' => ['method'          => "GET", 'header'          => "Accept-language: en\r\n" . "User-Agent: $_UA\r\n" . "accept: image/png\r\n", 'request_fulluri' => true]];
-            if (
-                isset($conf['proxy']['host'], $conf['proxy']['port'])
+            $opts = ['http' => [
+                'method' => "GET",
+                'header' => "Accept-language: en\r\n" . "User-Agent: $_UA\r\n" . "accept: image/png\r\n" . "Referer: " . DOKU_URL . "\r\n",
+                'request_fulluri' => true
+            ]];
+            if (isset($conf['proxy']['host'], $conf['proxy']['port'])
                 && $conf['proxy']['host'] !== ''
                 && $conf['proxy']['port'] !== ''
             ) {
@@ -454,7 +461,7 @@ class StaticMap
      * @param string $url
      * @return string|false
      */
-    public function checkTileCache(string $url)
+    public function checkTileCache(string $url): string|false
     {
         $filename = $this->tileUrlToFilename($url);
         if (file_exists($filename)) {
@@ -464,8 +471,8 @@ class StaticMap
     }
 
     /**
-     *
      * @param string $url
+     * @return string
      */
     public function tileUrlToFilename(string $url): string
     {
@@ -478,7 +485,7 @@ class StaticMap
      * @param string $url
      * @param mixed  $data
      */
-    public function writeTileToCache($url, $data): void
+    public function writeTileToCache(string $url, mixed $data): void
     {
         $filename = $this->tileUrlToFilename($url);
         $this->mkdirRecursive(dirname($filename), 0777);
@@ -611,7 +618,7 @@ class StaticMap
 
     /**
      * Draw kml trace on the map.
-     * @throws exception when loading the KML fails
+     * @throws Exception when loading the KML fails
      */
     public function drawKML(): void
     {
@@ -668,7 +675,7 @@ class StaticMap
      * @param int     $colour
      *            drawing colour
      */
-    private function drawPolygon($polygon, int $colour)
+    private function drawPolygon(Polygon $polygon, int $colour): void
     {
         // TODO implementation of drawing holes,
         // maybe draw the polygon to an in-memory image and use imagecopy, draw polygon in col., draw holes in bgcol?
@@ -676,7 +683,7 @@ class StaticMap
         // print_r('Polygon:<br />');
         // print_r($polygon);
         $extPoints = [];
-        // extring is a linestring actually..
+        // extRing is a linestring actually...
         $extRing = $polygon->exteriorRing();
 
         for ($i = 1; $i < $extRing->numGeometries(); $i++) {
@@ -700,10 +707,10 @@ class StaticMap
      * Draw a line on the map.
      *
      * @param LineString $line
-     * @param int        $colour
+     * @param int $colour
      *            drawing colour
      */
-    private function drawLineString($line, $colour)
+    private function drawLineString(LineString $line, int $colour): void
     {
         imagesetthickness($this->image, 2);
         for ($p = 1; $p < $line->numGeometries(); $p++) {
@@ -733,10 +740,10 @@ class StaticMap
      * Draw a point on the map.
      *
      * @param Point $point
-     * @param int   $colour
+     * @param int $colour
      *            drawing colour
      */
-    private function drawPoint($point, $colour)
+    private function drawPoint(Point $point, int $colour): void
     {
         imagesetthickness($this->image, 2);
         // translate to paper space
@@ -758,9 +765,9 @@ class StaticMap
 
     /**
      * Draw gpx trace on the map.
-     * @throws exception when loading the GPX fails
+     * @throws Exception when loading the GPX fails
      */
-    public function drawGPX()
+    public function drawGPX(): void
     {
         $col     = imagecolorallocatealpha($this->image, 0, 0, 255, .4 * 127);
         $gpxgeom = geoPHP::load(file_get_contents($this->gpxFileName), 'gpx');
@@ -769,9 +776,9 @@ class StaticMap
 
     /**
      * Draw geojson on the map.
-     * @throws exception when loading the JSON fails
+     * @throws Exception when loading the JSON fails
      */
-    public function drawGeojson()
+    public function drawGeojson(): void
     {
         $col     = imagecolorallocatealpha($this->image, 255, 0, 255, .4 * 127);
         $gpxgeom = geoPHP::load(file_get_contents($this->geojsonFileName), 'json');
@@ -781,7 +788,7 @@ class StaticMap
     /**
      * add copyright and origin notice and icons to the map.
      */
-    public function drawCopyright()
+    public function drawCopyright(): void
     {
         $logoBaseDir = __DIR__ . '/' . 'logo/';
         $logoImg     = imagecreatefrompng($logoBaseDir . $this->tileInfo ['openstreetmap'] ['logo']);

--- a/StaticMap.php
+++ b/StaticMap.php
@@ -67,7 +67,7 @@ class StaticMap
         // assume these are 16x16 px
         'rest' => ['regex' => '/^(?!lightblue(\d+)$)(?!(ww_\S+$))(?!marker(|-blue|-gold|-green|-red)+$)(.*)/', 'extension' => '.png', 'shadow' => 'marker_shadow.png', 'offsetImage' => '-8,-8', 'offsetShadow' => '-1,-1'],
     ];
-    // note event hough $centerX, $centerY, $offsetX and $offsetY are defined as float,
+    // note even though $centerX, $centerY, $offsetX and $offsetY are defined as float,
     //   these are actually integer numbers, but the php floor()/ceil() functions return a float
     private float $centerX;
     private float $centerY;
@@ -274,7 +274,18 @@ class StaticMap
     {
         return implode(
             "&",
-            [$this->zoom, $this->lat, $this->lon, $this->width, $this->height, serialize($this->markers), $this->maptype, $this->kmlFileName, $this->gpxFileName, $this->geojsonFileName]
+            [
+                $this->zoom,
+                $this->lat,
+                $this->lon,
+                $this->width,
+                $this->height,
+                serialize($this->markers),
+                $this->maptype,
+                $this->kmlFileName,
+                $this->gpxFileName,
+                $this->geojsonFileName
+            ]
         );
     }
 
@@ -383,13 +394,14 @@ class StaticMap
                 $tileData = $this->fetchTile($url);
                 if ($tileData) {
                     $tileImage = imagecreatefromstring($tileData);
-                } else {
+                }
+                if (!$tileData || $tileImage === false || $tileImage === null) {
                     $tileImage = imagecreate($this->tileSize, $this->tileSize);
                     $color     = imagecolorallocate($tileImage, 255, 255, 255);
                     @imagestring($tileImage, 1, 127, 127, 'err', $color);
                 }
-                $destX = ($x - $startX) * $this->tileSize + $this->offsetX;
-                $destY = ($y - $startY) * $this->tileSize + $this->offsetY;
+                $destX = (int) ($x - $startX) * $this->tileSize + $this->offsetX;
+                $destY = (int) ($y - $startY) * $this->tileSize + $this->offsetY;
                 Logger::debug("imagecopy tile into image: $destX, $destY", $this->tileSize);
                 imagecopy(
                     $this->image,
@@ -406,16 +418,21 @@ class StaticMap
     }
 
     /**
-     * Fetch a tile and (if configured) store it in the cache.
+     * Fetch a tile (from the source or from the cache) and optionally store it in the cache,
+     * returns false if the tile is not a valid image.
      * @param string $url
      * @return bool|string
      * @todo refactor this to use dokuwiki\HTTP\HTTPClient or dokuwiki\HTTP\DokuHTTPClient
      *          for better proxy handling...
      */
-    public function fetchTile(string $url)
+    public function fetchTile(string $url): bool|string
     {
-        if ($this->useTileCache && ($cached = $this->checkTileCache($url)))
-            return $cached;
+        if ($this->useTileCache) {
+            $cached = $this->checkTileCache($url);
+            if ($cached) {
+                return $cached;
+            }
+        }
 
         $_UA = 'Mozilla/4.0 (compatible; DokuWikiSpatial HTTP Client; ' . PHP_OS . ')';
         if (function_exists("curl_init")) {
@@ -426,7 +443,7 @@ class StaticMap
             curl_setopt($ch, CURLOPT_REFERER, DOKU_URL);
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
             curl_setopt($ch, CURLOPT_URL, $url . $this->apikey);
-            Logger::debug("StaticMap::fetchTile: getting: $url using curl_exec");
+            Logger::debug("fetchTile: getting: $url using curl_exec");
             $tile = curl_exec($ch);
             curl_close($ch);
         } else {
@@ -445,15 +462,18 @@ class StaticMap
             }
 
             $context = stream_context_create($opts);
-            Logger::debug(
-                "StaticMap::fetchTile: getting: $url . $this->apikey using file_get_contents and options $opts"
-            );
+            Logger::debug("fetchTile: getting: $url . $this->apikey using file_get_contents and options", $opts);
             $tile = file_get_contents($url . $this->apikey, false, $context);
         }
-        if ($tile && $this->useTileCache) {
-            $this->writeTileToCache($url, $tile);
+
+        // check if we retrieved a valid image
+        if (@imagecreatefromstring($tile) !== false) {
+            if ($tile && $this->useTileCache) {
+                $this->writeTileToCache($url, $tile);
+            }
+            return $tile;
         }
-        return $tile;
+        return false;
     }
 
     /**
@@ -564,11 +584,11 @@ class StaticMap
                 $markerShadowImg = imagecreatefrompng($markerBaseDir . '/' . $markerShadow);
             }
             // calc position
-            $destX = floor(
+            $destX = (int) floor(
                 ($this->width / 2) -
                 $this->tileSize * ($this->centerX - $this->lonToTile($markerLon, $this->zoom))
             );
-            $destY = floor(
+            $destY = (int) floor(
                 ($this->height / 2) -
                 $this->tileSize * ($this->centerY - $this->latToTile($markerLat, $this->zoom))
             );

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   openlayersmap
 author Mark C. Prins
 email  mprins@users.sf.net
-date   2026-04-18
+date   2026-05-11
 name   OpenLayers map plugin for DokuWiki
 desc   Provides a syntax for rendering OpenLayers based maps in wiki pages.
 url    https://www.dokuwiki.org/plugin:openlayersmap


### PR DESCRIPTION
Not strictly required, but it could be a reason for blocking: 
- https://wiki.openstreetmap.org/wiki/Referer
- https://operations.osmfoundation.org/policies/tiles/

Also fix #105 
```
<olmap id="olMap" width="200px" height="200px" lat="0" lon="55" zoom="0" controls="1" baselyr="OpenStreetMap" kmlfile=":sitemap.kml" summary="This map shows a kml trace">
-20,50,1,.8,marker-green.png,Just a spot
-80,50,1,.8,marker-green.png,Just another spot
</olmap>
```
<img width="200" height="200" alt="3e5d195cc9217e6ba08ed51358ba" src="https://github.com/user-attachments/assets/08d47914-9fb8-45e0-97af-6a042fc2f344" />



```
<olmap id="olMap" width="800px" height="800px" lat="0" lon="55" zoom="2" controls="1" baselyr="OpenStreetMap" kmlfile=":sitemap.kml" summary="This map shows a kml trace">
-20,50,1,.8,marker-green.png,Just a spot
-80,50,1,.8,marker-green.png,Just another spot
</olmap>
```

<img width="800" height="800" alt="8c1e255df8d405039a47cc6ab18e" src="https://github.com/user-attachments/assets/12890835-120c-4c40-987f-5c8ce1087c3a" />
