### PR TITLE
Update regex assertions to use assertMatchesRegularExpression

### DIFF
--- a/_test/general.test.php
+++ b/_test/general.test.php
@@ -44,9 +44,9 @@ class general_plugin_openlayersmap_test extends DokuWikiTest {
         self::assertArrayHasKey('url', $info);
 
         self::assertEquals('openlayersmap', $info['base']);
-        self::assertRegExp('/^https?:\/\//', $info['url']);
+        self::assertMatchesRegularExpression('/^https?:\/\//', $info['url']);
         self::assertTrue(mail_isvalid($info['email']));
-        self::assertRegExp('/^\d\d\d\d-\d\d-\d\d$/', $info['date']);
+        self::assertMatchesRegularExpression('/^\d\d\d\d-\d\d-\d\d$/', $info['date']);
         self::assertNotFalse(strtotime($info['date']));
     }
 


### PR DESCRIPTION
`assertRegExp()` is deprecated and will be removed in PHPUnit 10. Refactor your code to use assertMatchesRegularExpression() instead

close #108