### PR TITLE
Update StaticMap.php: en route to fixing issue 105

### DIFF
--- a/StaticMap.php
+++ b/StaticMap.php
@@ -361,7 +361,9 @@ class StaticMap
         $startX        = floor($this->centerX - ($this->width / $this->tileSize) / 2);
         $startY        = floor($this->centerY - ($this->height / $this->tileSize) / 2);
         $endX          = ceil($this->centerX + ($this->width / $this->tileSize) / 2);
+        $endX          = min($endX, pow(2,$this->zoom)-1);
         $endY          = ceil($this->centerY + ($this->height / $this->tileSize) / 2);
+        $endY          = min($endY, pow(2,$this->zoom)-1);
         $this->offsetX = -floor(($this->centerX - floor($this->centerX)) * $this->tileSize);
         $this->offsetY = -floor(($this->centerY - floor($this->centerY)) * $this->tileSize);
         $this->offsetX += floor($this->width / 2);

--- a/StaticMap.php
+++ b/StaticMap.php
@@ -380,7 +380,9 @@ class StaticMap
                 $tileData = $this->fetchTile($url);
                 if ($tileData) {
                     $tileImage = imagecreatefromstring($tileData);
-                } else {
+                }
+                // If fetching or creating failed, make a blank placeholder image
+                if (!$tileData || $tileImage === false || $tileImage === null) {
                     $tileImage = imagecreate($this->tileSize, $this->tileSize);
                     $color     = imagecolorallocate($tileImage, 255, 255, 255);
                     @imagestring($tileImage, 1, 127, 127, 'err', $color);


### PR DESCRIPTION
// If fetching or creating failed, make a blank placeholder image
if (!$tileData || $tileImage === false || $tileImage === null) {

As written with @Svetlana-T and tested on a server. Now zoom level 0 "works": gives map, instead of bringing the whole page down with an error.

Attempt to solve issue #105 .